### PR TITLE
Add session argument to setup, to make the setup compatible with pip > 1.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 from pip.req import parse_requirements
 
 # parse_requirements() returns generator of pip.req.InstallRequirement objects
-install_reqs = parse_requirements("requirements.txt")
+install_reqs = parse_requirements("requirements.txt", session=False)
 
 # reqs is a list of requirement
 # e.g. ['django==1.5.1', 'mezzanine==1.4.6']


### PR DESCRIPTION
Installing the requirements with pip > 1.6 fails, because a session argument is expected. The change is backwards compatible, for older versions of pip
