### PR TITLE
Add db engine option pool_pre_ping

### DIFF
--- a/frestq/app.py
+++ b/frestq/app.py
@@ -248,7 +248,7 @@ RESERVATION_TIMEOUT = 60
 app.config.from_object(__name__)
 
 # boostrap our little application
-db = SQLAlchemy(app)
+db = SQLAlchemy(app, engine_options={"pool_pre_ping": True})
 
 # set to True to get real security
 ALLOW_ONLY_SSL_CONNECTIONS = False

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 APScheduler @ git+https://github.com/edulix/apscheduler#egg=apscheduler
 requests==2.22.0
 Flask==1.0.0
-Flask-SQLAlchemy==2.4.1
+Flask-SQLAlchemy==2.4.4
 Jinja2==2.10.1
 MarkupSafe==0.23
-SQLAlchemy==1.3.0
+SQLAlchemy==1.3.23
 Werkzeug==1.0.1
 argparse==1.2.1
 cffi==1.14.4


### PR DESCRIPTION
There is a problem with the election-orchestra after restarting the
postgresql server, we get an error because the database connection is
wrong.

This patch uses the Pessimistic Disconnect Handling, so before every
connection there's a ping query to check if it's still alive.

https://docs.sqlalchemy.org/en/13/core/pooling.html?highlight=reconnect#disconnect-handling-pessimistic